### PR TITLE
Removed auto version upgrade for aws-sdk from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "angular-touch": "^1.5.8",
     "angular-ui-bootstrap": "^2.2.0",
     "angular-ui-router": "^0.3.1",
-    "aws-sdk": "^2.6.6",
+    "aws-sdk": "2.6.6",
     "aws-sdk-mock": "1.5.0",
     "babel-core": "^6.17.0",
     "babel-loader": "^6.2.5",


### PR DESCRIPTION
Something problematic with the new version of aws-sdk may be breaking our photo upload route.